### PR TITLE
Update AddLoot() to not capture references to source loot

### DIFF
--- a/src/loot-tables-advanced.ts
+++ b/src/loot-tables-advanced.ts
@@ -35,7 +35,7 @@ export function AddLoot<T extends string = string>(
 ): Loot {
   const i = loot.findIndex((e) => e.id == item.id)
   if (i >= 0) loot[i].quantity += item.quantity
-  else loot.push(item)
+  else loot.push({ id: item.id, quantity: item.quantity })
   return loot
 }
 


### PR DESCRIPTION
This PR updates `AddLoot()` to avoid capture of the source objects passed into it.

The issue seen is this:
```
const destination: Loot<string> = [];
const sourceA: Loot<string> = [ { id: "A", value: 100 } ];
const sourceB: Loot<string> = [ { id: "B", value: 200 } ];
const sourceAB: Loot<string> = [ { id: "A", value: 300 },  { id: "B", value: 300 } ];

mergeLoot(destination, sourceA);
mergeLoot(destination, sourceB);
mergeLoot(destination, sourceAB);

assert(sourceA[0].value === 100); // FAIL, has been changed to 400
assert(sourceB[0].value === 100); // FAIL, has been changed to 500
```
